### PR TITLE
Fix for #12

### DIFF
--- a/src/main/java/cambio/simulator/entities/NamedEntity.java
+++ b/src/main/java/cambio/simulator/entities/NamedEntity.java
@@ -1,0 +1,31 @@
+package cambio.simulator.entities;
+
+import desmoj.core.simulator.Entity;
+import desmoj.core.simulator.Model;
+
+/**
+ * @author Lion Wagner
+ */
+public class NamedEntity extends Entity {
+
+    private String plainName;
+
+    public NamedEntity(Model model, String s, boolean b) {
+        super(model, s, b);
+        this.plainName = s;
+    }
+
+    public String getPlainName() {
+        return getName().substring(0, getName().length() - ((int) Math.ceil(Math.log10(getIdentNumber()))));
+    }
+
+    @Override
+    public void rename(String s) {
+        super.rename(s);
+        this.plainName = s;
+    }
+
+    public String getQuotedPlainName() {
+        return "'" + getPlainName() + "'";
+    }
+}

--- a/src/main/java/cambio/simulator/entities/NamedEntity.java
+++ b/src/main/java/cambio/simulator/entities/NamedEntity.java
@@ -4,27 +4,40 @@ import desmoj.core.simulator.Entity;
 import desmoj.core.simulator.Model;
 
 /**
+ * Class that adds further options for the retrieving of names of entities.
+ * Specifically it provides a plain name for each entity that does not contain the number assinged by DesmoJ.
+ * However, these plain names are not guaranteed to be unique.
+ *
+ * <p>
+ * Plain names should be used when it comes to generating new entity names based on other entity names to prevent
+ * chains of unique identifiers.
+ *
  * @author Lion Wagner
  */
 public class NamedEntity extends Entity {
 
     private String plainName;
 
-    public NamedEntity(Model model, String s, boolean b) {
-        super(model, s, b);
-        this.plainName = s;
+    public NamedEntity(Model model, String name, boolean showInTrace) {
+        super(model, name, showInTrace);
+        this.plainName = name;
     }
 
     public String getPlainName() {
-        return getName().substring(0, getName().length() - ((int) Math.ceil(Math.log10(getIdentNumber()))));
+        return this.plainName;
     }
 
     @Override
-    public void rename(String s) {
-        super.rename(s);
-        this.plainName = s;
+    public void rename(String name) {
+        super.rename(name);
+        this.plainName = name;
     }
 
+    /**
+     * Gets a quoted version of the plain name of this object.
+     *
+     * @return the plain name of this entity surrounded with ' quotes.
+     */
     public String getQuotedPlainName() {
         return "'" + getPlainName() + "'";
     }

--- a/src/main/java/cambio/simulator/entities/microservice/Microservice.java
+++ b/src/main/java/cambio/simulator/entities/microservice/Microservice.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import cambio.simulator.entities.NamedEntity;
 import cambio.simulator.entities.networking.InternalRequest;
 import cambio.simulator.entities.patterns.InstanceOwnedPattern;
 import cambio.simulator.entities.patterns.LoadBalancer;
@@ -18,7 +19,6 @@ import cambio.simulator.export.ContinuousMultiDataPointReporter;
 import cambio.simulator.export.MultiDataPointReporter;
 import cambio.simulator.parsing.PatternData;
 import desmoj.core.dist.NumericalDist;
-import desmoj.core.simulator.Entity;
 import desmoj.core.simulator.Event;
 import desmoj.core.simulator.Model;
 
@@ -45,7 +45,7 @@ import desmoj.core.simulator.Model;
  * @see ServiceOwnedPattern
  * @see InstanceOwnedPattern
  */
-public class Microservice extends Entity {
+public class Microservice extends NamedEntity {
     private final Set<MicroserviceInstance> instancesSet = new HashSet<>();
     private final LoadBalancer loadBalancer;
     private final MultiDataPointReporter reporter;

--- a/src/main/java/cambio/simulator/entities/microservice/MicroserviceInstance.java
+++ b/src/main/java/cambio/simulator/entities/microservice/MicroserviceInstance.java
@@ -201,7 +201,7 @@ public class MicroserviceInstance extends RequestSender implements IRequestUpdat
         //3. request does have dependencies -> create internal request
         if (request.isCompleted()) {
             RequestAnswer answer = new RequestAnswer(request, this);
-            sendRequest("Request_Answer_" + request.getQuotedName(), answer, request.getRequester());
+            sendRequest("Request_Answer_" + request.getPlainName(), answer, request.getRequester());
 
             int size = currentRequestsToHandle.size();
             currentRequestsToHandle.remove(request);
@@ -226,7 +226,7 @@ public class MicroserviceInstance extends RequestSender implements IRequestUpdat
                 Request internalRequest = new InternalRequest(getModel(), this.traceIsOn(), dependency, this);
                 sendRequest(String.format("Collecting dependency %s", dependency.getQuotedName()), internalRequest,
                     dependency.getTargetService());
-                sendTraceNote(String.format("Try 1, send Request: %s ", internalRequest.getQuotedName()));
+                sendTraceNote(String.format("Try 1, send Request: %s ", internalRequest.getQuotedPlainName()));
             }
         }
     }

--- a/src/main/java/cambio/simulator/entities/microservice/Operation.java
+++ b/src/main/java/cambio/simulator/entities/microservice/Operation.java
@@ -2,6 +2,7 @@ package cambio.simulator.entities.microservice;
 
 import java.util.Arrays;
 
+import cambio.simulator.entities.NamedEntity;
 import cambio.simulator.entities.networking.Dependency;
 import cambio.simulator.entities.networking.NetworkDependency;
 import cambio.simulator.parsing.DependencyParser;
@@ -13,7 +14,7 @@ import desmoj.core.simulator.Model;
  * An {@code Operation} represents an endpoint of a service. It has a specific computational demand and may have
  * dependencies.
  */
-public class Operation extends Entity {
+public class Operation extends NamedEntity{
     private final int demand;
     private final Microservice ownerMS;
     private Dependency[] dependencies = new Dependency[0];

--- a/src/main/java/cambio/simulator/entities/microservice/Operation.java
+++ b/src/main/java/cambio/simulator/entities/microservice/Operation.java
@@ -7,14 +7,13 @@ import cambio.simulator.entities.networking.Dependency;
 import cambio.simulator.entities.networking.NetworkDependency;
 import cambio.simulator.parsing.DependencyParser;
 import desmoj.core.dist.NumericalDist;
-import desmoj.core.simulator.Entity;
 import desmoj.core.simulator.Model;
 
 /**
  * An {@code Operation} represents an endpoint of a service. It has a specific computational demand and may have
  * dependencies.
  */
-public class Operation extends NamedEntity{
+public class Operation extends NamedEntity {
     private final int demand;
     private final Microservice ownerMS;
     private Dependency[] dependencies = new Dependency[0];

--- a/src/main/java/cambio/simulator/entities/networking/InternalRequest.java
+++ b/src/main/java/cambio/simulator/entities/networking/InternalRequest.java
@@ -23,7 +23,8 @@ public class InternalRequest extends Request {
                            MicroserviceInstance requester) {
         super(model,
             String
-                .format("Cascading Request %s(%s)", dependency.getTargetOp().getOwnerMS().getPlainName(), dependency.getTargetOp().getPlainName()),
+                .format("Cascading Request %s(%s)", dependency.getTargetOp().getOwnerMS().getPlainName(),
+                    dependency.getTargetOp().getPlainName()),
             showInTrace,
             dependency.getParentRequest(),
             dependency.getTargetOp(), requester);

--- a/src/main/java/cambio/simulator/entities/networking/InternalRequest.java
+++ b/src/main/java/cambio/simulator/entities/networking/InternalRequest.java
@@ -23,7 +23,7 @@ public class InternalRequest extends Request {
                            MicroserviceInstance requester) {
         super(model,
             String
-                .format("Cascading Request %s(%s)", dependency.getTargetOp().getOwnerMS(), dependency.getTargetOp()),
+                .format("Cascading Request %s(%s)", dependency.getTargetOp().getOwnerMS().getPlainName(), dependency.getTargetOp().getPlainName()),
             showInTrace,
             dependency.getParentRequest(),
             dependency.getTargetOp(), requester);

--- a/src/main/java/cambio/simulator/entities/networking/NetworkDependency.java
+++ b/src/main/java/cambio/simulator/entities/networking/NetworkDependency.java
@@ -35,7 +35,8 @@ public class NetworkDependency extends NamedEntity {
      * @param dependencyData generic data that describes this dependency.
      */
     public NetworkDependency(Model model, Request parentRequest, Operation targetOp, Dependency dependencyData) {
-        super(model, String.format("Dependency(%s)of[%s]", targetOp.getName(), parentRequest.getName()), false);
+        super(model, String.format("Dependency(%s)of[%s]", targetOp.getPlainName(), parentRequest.getPlainName()),
+            false);
         this.parentRequest = parentRequest;
         this.targetOp = targetOp;
         this.targetMicroservice = targetOp.getOwnerMS();

--- a/src/main/java/cambio/simulator/entities/networking/NetworkDependency.java
+++ b/src/main/java/cambio/simulator/entities/networking/NetworkDependency.java
@@ -2,10 +2,10 @@ package cambio.simulator.entities.networking;
 
 import java.util.Objects;
 
+import cambio.simulator.entities.NamedEntity;
 import cambio.simulator.entities.microservice.Microservice;
 import cambio.simulator.entities.microservice.MicroserviceInstance;
 import cambio.simulator.entities.microservice.Operation;
-import desmoj.core.simulator.Entity;
 import desmoj.core.simulator.Model;
 
 /**
@@ -17,7 +17,7 @@ import desmoj.core.simulator.Model;
  * @see Request
  * @see MicroserviceInstance
  */
-public class NetworkDependency extends Entity {
+public class NetworkDependency extends NamedEntity {
 
     private final Request parentRequest;
     private final Microservice targetMicroservice;

--- a/src/main/java/cambio/simulator/entities/networking/NetworkRequestSendEvent.java
+++ b/src/main/java/cambio/simulator/entities/networking/NetworkRequestSendEvent.java
@@ -97,12 +97,12 @@ public class NetworkRequestSendEvent extends NetworkRequestEvent {
             cancelEvent.schedule(new TimeSpan(nextDelay));
         } else {
             receiverEvent = new NetworkRequestReceiveEvent(getModel(),
-                String.format("Receiving of %s", travelingRequest.getQuotedName()), traceIsOn(), travelingRequest,
+                String.format("Receiving of %s", travelingRequest.getQuotedPlainName()), traceIsOn(), travelingRequest,
                 targetInstance);
             receiverEvent.schedule(new TimeSpan(nextDelay));
 
             timeoutEvent =
-                new NetworkRequestTimeoutEvent(getModel(), "Timeout Checker for " + travelingRequest.getName(),
+                new NetworkRequestTimeoutEvent(getModel(), "Timeout Checker for " + travelingRequest.getPlainName(),
                     getModel().traceIsOn(), travelingRequest);
             travelingRequest.addUpdateListener(timeoutEvent);
 

--- a/src/main/java/cambio/simulator/entities/networking/Request.java
+++ b/src/main/java/cambio/simulator/entities/networking/Request.java
@@ -6,10 +6,10 @@ import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
 
+import cambio.simulator.entities.NamedEntity;
 import cambio.simulator.entities.microservice.MicroserviceInstance;
 import cambio.simulator.entities.microservice.Operation;
 import cambio.simulator.misc.Util;
-import desmoj.core.simulator.Entity;
 import desmoj.core.simulator.Model;
 import desmoj.core.simulator.TimeInstant;
 import org.apache.commons.math3.util.Precision;
@@ -19,7 +19,7 @@ import org.apache.commons.math3.util.Precision;
  *
  * @author Lion Wagner
  */
-public abstract class Request extends Entity {
+public abstract class Request extends NamedEntity {
     public final Operation operation;
     private final Set<NetworkDependency> dependencies = new HashSet<>();
     private final Request parent;

--- a/src/main/java/cambio/simulator/entities/networking/RequestAnswer.java
+++ b/src/main/java/cambio/simulator/entities/networking/RequestAnswer.java
@@ -21,7 +21,7 @@ public final class RequestAnswer extends Request {
      */
     public RequestAnswer(Request wrappedRequest, MicroserviceInstance answerSender) {
         super(wrappedRequest.getModel(),
-            "Request_Answer_" + wrappedRequest.getName(),
+            "Request_Answer_" + wrappedRequest.getPlainName(),
             wrappedRequest.traceIsOn(),
             wrappedRequest,
             new Operation(wrappedRequest.getModel(), "Dummy", false, null, 0),

--- a/src/main/java/cambio/simulator/entities/networking/RequestSender.java
+++ b/src/main/java/cambio/simulator/entities/networking/RequestSender.java
@@ -3,9 +3,9 @@ package cambio.simulator.entities.networking;
 import java.util.Objects;
 import java.util.TreeSet;
 
+import cambio.simulator.entities.NamedEntity;
 import cambio.simulator.entities.microservice.Microservice;
 import cambio.simulator.entities.microservice.MicroserviceInstance;
-import desmoj.core.simulator.Entity;
 import desmoj.core.simulator.Model;
 import desmoj.core.simulator.TimeInstant;
 import desmoj.core.simulator.TimeSpan;
@@ -15,7 +15,7 @@ import desmoj.core.simulator.TimeSpan;
  *
  * @author Lion Wagner
  */
-public class RequestSender extends Entity {
+public class RequestSender extends NamedEntity {
 
     private final TreeSet<IRequestUpdateListener> updateListeners = new TreeSet<>();
     /**

--- a/src/main/java/cambio/simulator/entities/patterns/RetryManager.java
+++ b/src/main/java/cambio/simulator/entities/patterns/RetryManager.java
@@ -88,13 +88,14 @@ public class RetryManager extends NetworkPattern implements IRequestUpdateListen
             Request newRequest = new InternalRequest(getModel(), this.traceIsOn(), dep,
                 request.getRequester()); //updates the dependency that had the original request as child
             if (handler == null || tries == maxTries - 1) {
-                owner.sendRequest(String.format("Collecting dependency %s", dep.getQuotedName()), newRequest,
+                owner.sendRequest(String.format("Collecting dependency %s", dep.getQuotedPlainName()), newRequest,
                     dep.getTargetService(), new TimeSpan(delay));
             } else {
-                owner.sendRequest(String.format("Collecting dependency %s", dep.getQuotedName()), newRequest, handler,
+                owner.sendRequest(String.format("Collecting dependency %s", dep.getQuotedPlainName()), newRequest,
+                    handler,
                     new TimeSpan(delay));
             }
-            sendTraceNote(String.format("Try %d, send Request: %s", tries + 1, newRequest.getQuotedName()));
+            sendTraceNote(String.format("Try %d, send Request: %s", tries + 1, newRequest.getQuotedPlainName()));
         } else {
             request.getUpdateListeners().forEach(iRequestUpdateListener -> iRequestUpdateListener
                 .onRequestFailed(request, when, RequestFailedReason.MAX_RETRIES_REACHED));

--- a/src/main/java/cambio/simulator/resources/cpu/CPU.java
+++ b/src/main/java/cambio/simulator/resources/cpu/CPU.java
@@ -147,7 +147,7 @@ public class CPU extends ExternalEvent {
 
             ComputationBurstCompletedEvent endEvent = new ComputationBurstCompletedEvent(getModel(),
                 String.format("Computation burst finished of %s",
-                    nextProcess.getRequest().getQuotedName()),
+                    nextProcess.getRequest().getQuotedPlainName()),
                 debugIsOn(),
                 nextProcess,
                 this,

--- a/src/main/java/cambio/simulator/resources/cpu/ComputationBurstCompletedEvent.java
+++ b/src/main/java/cambio/simulator/resources/cpu/ComputationBurstCompletedEvent.java
@@ -50,7 +50,7 @@ public class ComputationBurstCompletedEvent extends ExternalEvent {
             //notify the request that its computation finished
             Request request = endingProcess.getRequest();
             ComputationCompletedEvent completionEvent = new ComputationCompletedEvent(getModel(),
-                String.format("ComputationEnd %s", request.getQuotedName()),
+                String.format("ComputationEnd %s", request.getQuotedPlainName()),
                 getModel().traceIsOn());
             completionEvent.schedule(request, presentTime());
         }


### PR DESCRIPTION
This fix prevents most of the issues with the Naming catalog and provides a simplified naming interface for entities that allows for potentially non-unique plain names.